### PR TITLE
support CLI-style parameters in artisan command

### DIFF
--- a/playwright/src/index.ts
+++ b/playwright/src/index.ts
@@ -46,7 +46,10 @@ export class Laravel {
         return await response.json();
     }
 
-    async artisan(command: string, parameters: string[] = []) {
+    async artisan(
+        command: string,
+        parameters: string[] | Record<string, string | boolean | number> = []
+    ) {
         return await this.call<{code: number, output: string}>('/artisan', {command, parameters});
     }
 

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -19,7 +19,7 @@ class Controller
     {
 
         $command = (string) $request->string('command');
-        $parameters = (array) $request->input('parameters');
+        $parameters = $this->parseArtisanParameters((array) $request->input('parameters', []));
 
         $exitCode = Artisan::call($command, $parameters);
 
@@ -28,6 +28,59 @@ class Controller
             'output' => Artisan::output(),
         ]);
 
+    }
+
+    /**
+     * Parse CLI-style parameters into the format expected by Artisan::call().
+     *
+     * Converts:
+     *   ['--option=value', '--flag', 'argument']
+     * Into:
+     *   ['--option' => 'value', '--flag' => true, 'argument']
+     *
+     * Also supports associative arrays passed directly (for backwards compatibility).
+     *
+     * @param array<int|string, mixed> $parameters
+     * @return array<int|string, mixed>
+     */
+    private function parseArtisanParameters(array $parameters): array
+    {
+        $parsed = [];
+
+        foreach ($parameters as $key => $value) {
+            // Already an associative array entry (e.g., ['--option' => 'value'])
+            if (is_string($key)) {
+                $parsed[$key] = $value;
+                continue;
+            }
+
+            // CLI-style string parameter
+            if (is_string($value)) {
+                // Option with value: --option=value
+                if (str_starts_with($value, '--') && str_contains($value, '=')) {
+                    [$option, $optValue] = explode('=', $value, 2);
+                    $parsed[$option] = $optValue;
+                }
+                // Short option with value: -o=value
+                elseif (str_starts_with($value, '-') && !str_starts_with($value, '--') && str_contains($value, '=')) {
+                    [$option, $optValue] = explode('=', $value, 2);
+                    $parsed[$option] = $optValue;
+                }
+                // Flag (boolean option): --flag or -f
+                elseif (str_starts_with($value, '-')) {
+                    $parsed[$value] = true;
+                }
+                // Positional argument
+                else {
+                    $parsed[] = $value;
+                }
+            } else {
+                // Non-string value, keep as-is
+                $parsed[$key] = $value;
+            }
+        }
+
+        return $parsed;
     }
 
     public function truncate(Request $request) : JsonResponse

--- a/tests/Feature/ArtisanTest.php
+++ b/tests/Feature/ArtisanTest.php
@@ -3,6 +3,7 @@
 namespace Hyvor\LaravelPlaywright\Tests\Feature;
 
 use Hyvor\LaravelPlaywright\Tests\TestCase;
+use Illuminate\Support\Facades\Artisan;
 
 class ArtisanTest extends TestCase
 {
@@ -20,6 +21,101 @@ class ArtisanTest extends TestCase
         $this->assertEquals(0, $json['code']);
         $this->assertStringContainsString('playwright/artisan', (string) $json['output']);
 
+    }
+
+    public function testRunsArtisanCommandWithCliStyleParameters(): void
+    {
+        Artisan::command('test:params {--name=}', function () {
+            /** @var \Illuminate\Console\Command $this */
+            $this->info('Name: ' . $this->option('name'));
+        });
+
+        /** @var array<string, mixed> $json */
+        $json = $this->post('playwright/artisan', [
+            'command' => 'test:params',
+            'parameters' => ['--name=John']
+        ])
+            ->assertOk()
+            ->json();
+
+        $this->assertEquals(0, $json['code']);
+        $this->assertStringContainsString('Name: John', (string) $json['output']);
+    }
+
+    public function testRunsArtisanCommandWithAssociativeParameters(): void
+    {
+        Artisan::command('test:assoc {--name=}', function () {
+            /** @var \Illuminate\Console\Command $this */
+            $this->info('Name: ' . $this->option('name'));
+        });
+
+        /** @var array<string, mixed> $json */
+        $json = $this->post('playwright/artisan', [
+            'command' => 'test:assoc',
+            'parameters' => ['--name' => 'Jane']
+        ])
+            ->assertOk()
+            ->json();
+
+        $this->assertEquals(0, $json['code']);
+        $this->assertStringContainsString('Name: Jane', (string) $json['output']);
+    }
+
+    public function testRunsArtisanCommandWithBooleanFlags(): void
+    {
+        Artisan::command('test:flags {--force}', function () {
+            /** @var \Illuminate\Console\Command $this */
+            $this->info('Force: ' . ($this->option('force') ? 'yes' : 'no'));
+        });
+
+        /** @var array<string, mixed> $json */
+        $json = $this->post('playwright/artisan', [
+            'command' => 'test:flags',
+            'parameters' => ['--force']
+        ])
+            ->assertOk()
+            ->json();
+
+        $this->assertEquals(0, $json['code']);
+        $this->assertStringContainsString('Force: yes', (string) $json['output']);
+    }
+
+    public function testRunsArtisanCommandWithShortOptionFlags(): void
+    {
+        Artisan::command('test:short {--Q|--quick}', function () {
+            /** @var \Illuminate\Console\Command $this */
+            $this->info('Quick: ' . ($this->option('quick') ? 'yes' : 'no'));
+        });
+
+        /** @var array<string, mixed> $json */
+        $json = $this->post('playwright/artisan', [
+            'command' => 'test:short',
+            'parameters' => ['-Q']
+        ])
+            ->assertOk()
+            ->json();
+
+        $this->assertEquals(0, $json['code']);
+        $this->assertStringContainsString('Quick: yes', (string) $json['output']);
+    }
+
+    public function testRunsArtisanCommandWithPositionalArguments(): void
+    {
+        Artisan::command('test:positional {name}', function () {
+            /** @var \Illuminate\Console\Command $this */
+            $this->info('Name: ' . $this->argument('name'));
+        });
+
+        /** @var array<string, mixed> $json */
+        $json = $this->post('playwright/artisan', [
+            'command' => 'test:positional',
+            'parameters' => ['name' => 'Alice']
+        ])
+            ->assertOk()
+            ->json();
+
+        $this->assertEquals(0, $json['code']);
+        $this->assertStringContainsString('Name: Alice', (string) $json['output']);
     }
 
 }


### PR DESCRIPTION
Parse CLI-style string parameters (e.g., --option=value, --flag) into the associative array format that Artisan::call() expects. This allows users to write more intuitive commands like:
```ts
  await laravel.artisan('my:command', ['--user-id=123', '--force'])
```
instead of:
```ts
  await laravel.artisan('my:command', { '--user-id': '123', '--force': true })
```
Both formats are now supported for backwards compatibility.