### PR TITLE
Add `except` option to truncate for preserving baseline tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- `truncate()` now accepts an options object with `except` (keep these tables, truncate the rest). Requested table names are validated against the live schema listing and rejected (422) if unknown. Default behaviour (wipe all tables) is unchanged.
+
 # 2.0.0
 - Renamed PHP package from `hyvor/laravel-e2e` to `hyvor/laravel-playwright`
 - Introduces a new NPM package `@hyvor/laravel-playwright` for the frontend

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ test('example', async ({ laravel }) => {
     await laravel.truncate();
     // in specific DB connections
     await laravel.truncate(['connection1', 'connection2']);
+    // keep some tables (truncate everything else)
+    // useful to preserve a seeded baseline like reference/lookup tables
+    await laravel.truncate([], { except: ['countries', 'roles'] });
     
     
     // CREATE MODELS FROM FACTORIES

--- a/playwright/src/index.ts
+++ b/playwright/src/index.ts
@@ -50,8 +50,14 @@ export class Laravel {
         return await this.call<{code: number, output: string}>('/artisan', {command, parameters});
     }
 
-    async truncate(connections: (string|null)[] = []) {
-        return await this.call('/truncate', {connections});
+    async truncate(
+        connections: (string|null)[] = [],
+        options: {
+            except?: string[]
+        } = {}
+    ) {
+        const { except } = options;
+        return await this.call('/truncate', {connections, except});
     }
 
     async factory<CountT extends number | undefined = undefined>(

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Response;
+use Illuminate\Support\Facades\Schema;
 
 class Controller
 {
@@ -35,14 +36,30 @@ class Controller
 
         $request->validate([
             'connections' => 'nullable|array',
-            'connections.*' => 'nullable|string'
+            'connections.*' => 'nullable|string',
+            'except' => 'nullable|array',
+            'except.*' => 'string',
         ]);
 
         /** @var array<string|null> $connections */
         $connections = $request->input('connections') ?? [null];
+        /** @var string[]|null $except */
+        $except = $request->input('except');
+
+        if ($except !== null) {
+            foreach ($connections as $connection) {
+                /** @var string[] $tables */
+                $tables = Schema::connection($connection)->getTableListing();
+                $unknown = array_diff($except, $tables);
+
+                if (count($unknown) > 0) {
+                    abort(422, 'Unknown table(s): ' . implode(', ', $unknown));
+                }
+            }
+        }
 
         $truncate = new Services\Truncate();
-        $truncate->truncate($connections);
+        $truncate->truncate($connections, $except);
 
         return Response::json();
 

--- a/src/Services/Truncate.php
+++ b/src/Services/Truncate.php
@@ -10,21 +10,30 @@ class Truncate
 
     /**
      * @param array<null | string> $connections
+     * @param string[]|null $except Tables to keep (truncate everything else)
      */
-    public function truncate(array $connections = [null]) : void
+    public function truncate(array $connections = [null], ?array $except = null) : void
     {
 
         foreach ($connections as $connection) {
-            $this->truncateTablesOfConnection($connection);
+            $this->truncateTablesOfConnection($connection, $except);
         }
 
     }
 
-    private function truncateTablesOfConnection(?string $connection) : void
+    /**
+     * @param string[]|null $except
+     */
+    private function truncateTablesOfConnection(?string $connection, ?array $except) : void
     {
 
         /** @var string[] $tables */
         $tables = Schema::connection($connection)->getTableListing();
+
+        if ($except !== null) {
+            $tables = array_values(array_diff($tables, $except));
+        }
+
         Schema::disableForeignKeyConstraints();
 
         foreach ($tables as $table) {

--- a/tests/Feature/TruncateTest.php
+++ b/tests/Feature/TruncateTest.php
@@ -4,9 +4,24 @@ namespace Hyvor\LaravelPlaywright\Tests\Feature;
 
 use Hyvor\LaravelPlaywright\Tests\Helpers\UserModel;
 use Hyvor\LaravelPlaywright\Tests\TestCase;
+use Illuminate\Support\Facades\DB;
 
 class TruncateTest extends TestCase
 {
+
+    protected function tearDown(): void
+    {
+        DB::statement('drop table if exists countries');
+        parent::tearDown();
+    }
+
+    private function seedCountries(): void
+    {
+        DB::statement('drop table if exists countries');
+        DB::statement('create table countries (id bigserial, name varchar(255))');
+        DB::table('countries')->insert([['name' => 'Sri Lanka'], ['name' => 'Germany']]);
+    }
+
     public function testTruncates(): void
     {
         UserModel::factory()->count(3)->create();
@@ -16,4 +31,40 @@ class TruncateTest extends TestCase
 
         $this->assertCount(0, UserModel::all());
     }
+
+    public function testKeepsExceptTables(): void
+    {
+        $this->seedCountries();
+        UserModel::factory()->count(3)->create();
+
+        $this->postJson('/playwright/truncate', [
+            'except' => ['countries'],
+        ])->assertOk();
+
+        $this->assertCount(0, UserModel::all());
+        $this->assertSame(2, DB::table('countries')->count());
+    }
+
+    public function testFailsOnUnknownTableWithoutTruncating(): void
+    {
+        UserModel::factory()->count(3)->create();
+
+        $this->postJson('/playwright/truncate', [
+            'except' => ['does_not_exist'],
+        ])->assertStatus(422);
+
+        $this->assertCount(3, UserModel::all());
+    }
+
+    public function testEmptyExceptTruncatesEverything(): void
+    {
+        UserModel::factory()->count(3)->create();
+
+        $this->postJson('/playwright/truncate', [
+            'except' => [],
+        ])->assertOk();
+
+        $this->assertCount(0, UserModel::all());
+    }
+
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `except` option to `truncate()` so tests can reset transactional data while keeping a seeded baseline. Today `truncate()` wipes **every** table, which forces a full re-seed after each test when the database has reference/lookup data (e.g. `countries`, `roles`) that tests depend on. With `except`, those tables survive:

```ts
// wipe everything except the reference tables
await laravel.truncate([], { except: ['countries', 'roles'] });
```

## Behaviour

- `except` lists tables to **keep**; every other table is truncated.
- Requested table names are validated against the live schema listing (`Schema::getTableListing()`); if any are unknown the request is rejected with **422** before anything is truncated — a typo fails safe instead of silently truncating the wrong set.
- **Backward compatible**: with no options, `truncate()` wipes all tables exactly as before, and the existing `truncate(connections)` call shape is unchanged.

## Security

`truncate()` is destructive, so table names from the request are never interpolated into SQL. The only names ever passed to the truncate call come from the schema listing itself (via `array_diff`), and unknown names are rejected up front. The endpoint remains gated by the existing environment guard.

## Tests

Added feature tests covering: default wipe-all (unchanged), `except` preserves the listed table, an unknown table returns 422 without truncating anything, and an empty `except` wipes everything. Full suite passes on Postgres and PHPStan (level max) is clean.

## Notes

`except` covers the common "preserve baseline" case; `only`-style targeting was intentionally left out to keep the surface minimal.
